### PR TITLE
fix(lint): upgrade golangci-lint to v2.10.1 to fix buildssa panic

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,5 +1,10 @@
 # This has to be >= v1.57.0 for module plugin system support.
-version: v1.63.4
+# Upgraded to v2.10.1: the first v2 release containing the fix for
+# golangci-lint issue #6375 (buildssa panic: "interface conversion:
+# interface {} is nil, not *ctrlflow.CFGs"), triggered by the nilaway
+# plugin. The fix (PR #6376, making markDepsForAnalyzingSource recursive)
+# was never backported to the v1.x line.
+version: v2.10.1
 destination: ./build/
 name: custom-gcl
 plugins:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
+version: "2"
+
 linters:
-  disable-all: true
-  fast: false
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -13,12 +14,8 @@ linters:
     - errorlint
     - gocritic
     - godot
-    - gofmt
-    - gofumpt
-    - goimports
     - gomoddirectives
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -36,9 +33,8 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
     - tagliatelle
-    - tenv
+    - usetesting
     - testableexamples
     - thelper
     - tparallel
@@ -47,54 +43,59 @@ linters:
     - unused
     - usestdlibvars
     - wastedassign
+  settings:
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - hugeParam
+        - rangeExprCopy
+        - rangeValCopy
 
-linters-settings:
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - hugeParam
-      - rangeExprCopy
-      - rangeValCopy
+    errcheck:
+      # Report `a := b.(MyStruct)` when `a, ok := ...` should be.
+      check-type-assertions: true # Default: false
+      # Report skipped checks:`num, _ := strconv.Atoi(numStr)`.
+      check-blank: true # Default: false
+      exclude-functions:
+        - io/ioutil.ReadFile
+        - io.Copy(*bytes.Buffer)
+        - io.Copy(os.Stdout)
 
-  errcheck:
-    # Report `a := b.(MyStruct)` when `a, ok := ...` should be.
-    check-type-assertions: true # Default: false
-    # Report skipped checks:`num, _ := strconv.Atoi(numStr)`.
-    check-blank: true # Default: false
-    exclude-functions:
-      - io/ioutil.ReadFile
-      - io.Copy(*bytes.Buffer)
-      - io.Copy(os.Stdout)
+    # govet:
+      # disable:
+      #   - fieldalignment # I'm ok to waste some bytes
 
-  # govet:
-    # disable: 
-    #   - fieldalignment # I'm ok to waste some bytes
+    nakedret:
+      # No naked returns, ever.
+      max-func-lines: 1 # Default: 30
 
-  nakedret:
-    # No naked returns, ever.
-    max-func-lines: 1 # Default: 30
+    tagliatelle:
+      case:
+        rules:
+          json: snake # why it's not a `snake` by default?!
+          yaml: snake # why it's not a `snake` by default?!
+          xml: camel
+          bson: camel
+          avro: snake
+          mapstructure: kebab
 
-  tagliatelle:
-    case:
-      rules:
-        json: snake # why it's not a `snake` by default?!
-        yaml: snake # why it's not a `snake` by default?!
-        xml: camel
-        bson: camel
-        avro: snake
-        mapstructure: kebab
+    custom:
+      nilaway:
+        type: "module"
+        description: Static analysis tool to detect potential nil panics in Go code.
+        settings:
+          include-pkgs: ""
 
-  custom:
-    nilaway:
-      type: "module"
-      description: Static analysis tool to detect potential nil panics in Go code.
-      settings:
-        include-pkgs: ""
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
 
 output:
   show-stats: true


### PR DESCRIPTION
## Problem

CI fails intermittently with a golangci-lint panic. Example failure: [run 32714795314](https://github.com/fr12k/go-mask/actions/runs/32714795314/job/97393639497) (dependabot PR #48):

```
ERRO [linters_context/goanalysis] buildssa: panic during analysis:
interface conversion: interface {} is nil, not *ctrlflow.CFGs
```

The build then exits with status 7. The failure is **flaky** — the same PR sometimes passes (run 32714794510) and sometimes fails, depending on which non-initial package golangci-lint processes first.

## Root cause

This is [golangci-lint issue #6375](https://github.com/golangci/golangci-lint/issues/6375), triggered by the `nilaway` custom plugin.

The analyzer dependency chain is:

```
nilaway → buildssa → ctrlflow → inspect
```

`markDepsForAnalyzingSource()` in `pkg/goanalysis/runner_action.go` only marks **direct** horizontal deps for source analysis — it does not recurse. When `nilaway` fails to load cached facts for a non-initial package:

1. `nilaway` sets `needAnalyzeSource = true` and calls `markDepsForAnalyzingSource()`, which marks `buildssa`.
2. `buildssa.markDepsForAnalyzingSource()` is never called, so `ctrlflow.needAnalyzeSource` stays `false`.
3. `ctrlflow` returns immediately with a nil `Result`.
4. `buildssa` runs and panics on the unchecked type assertion `pass.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)`.

The upstream fix ([golangci-lint PR #6376](https://github.com/golangci/golangci-lint/pull/6376) — make `markDepsForAnalyzingSource` recursive) was released in **golangci-lint v2.10.1+** and was **never backported to the v1.x line** (verified: the function is identical/non-recursive in v1.63.4 through v1.64.8).

This project used golangci-lint v1.63.4 via the v1.x custom-gcl plugin system, so bumping within v1.x does **not** fix the panic.

## Fix

Upgrade golangci-lint from **v1.63.4 → v2.10.1** (the first v2 release containing the fix). This keeps `nilaway` enabled while eliminating the panic.

### Changes

**`.custom-gcl.yml`** — bump `version` from `v1.63.4` to `v2.10.1`.

**`.golangci.yml`** — migrate to the v2 config format:
- Add `version: "2"`
- `disable-all: true` → `default: none`
- `linters-settings:` → `linters.settings:`
- `gofmt`/`gofumpt`/`goimports` moved to `formatters.enable` (they are formatters, not linters, in v2)
- `gosimple`/`stylecheck` removed (merged into `staticcheck` in v2)
- `tenv` → `usetesting` (renamed in v2)
- `nilaway` plugin **retained** ✅

## Verification

Built `custom-gcl` from v2.10.1 + nilaway and ran it 5 times against go-mask — **zero panics** in all runs (the v1.63.4 version panicked flakily). The `.containifyci` lint with `--no-config` also passes (0 issues).

```
Run 1: panic count = 0
Run 2: panic count = 0
Run 3: panic count = 0
Run 4: panic count = 0
Run 5: panic count = 0
```

No source code changes — only lint configuration migration.

Refs: https://github.com/golangci/golangci-lint/issues/6375